### PR TITLE
Tippfehler korrigiert (Lang-s und Rund-s)

### DIFF
--- a/haml/index.haml
+++ b/haml/index.haml
@@ -34,22 +34,22 @@
                 %source{ :src => "data/dillgurke.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/dillgurke.ogg", :type => "audio/ogg"}
         .klang
-            %h2 Desinformation
+            %h2 De$information
             %audio{ :controls => "controls"}
                 %source{ :src => "data/desinformation.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/desinformation.ogg", :type => "audio/ogg"}
         .klang
-            %h2 Handys
+            %h2 Handy$
             %audio{ :controls => "controls"}
                 %source{ :src => "data/handys.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/handys.ogg", :type => "audio/ogg"}
         .klang
-            %h2 Widerholung
+            %h2 Wiederholung
             %audio{ :controls => "controls"}
                 %source{ :src => "data/wiederholung.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/wiederholung.ogg", :type => "audio/ogg"}
         .klang
-            %h2 Corioliskraft
+            %h2 Corioli$kraft
             %audio{ :controls => "controls"}
                 %source{ :src => "data/corioliskraft.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/corioliskraft.ogg", :type => "audio/ogg"}
@@ -59,7 +59,7 @@
                 %source{ :src => "data/bullen.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/bullen.ogg", :type => "audio/ogg"}
         .klang
-            %h2 Geheimnis
+            %h2 Geheimni$
             %audio{ :controls => "controls"}
                 %source{ :src => "data/geheimnis.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/geheimnis.ogg", :type => "audio/ogg"}
@@ -89,7 +89,7 @@
                 %source{ :src => "data/zeit.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/zeit.ogg", :type => "audio/ogg"}
         .klang
-            %h2 Wetterkriegsfuehrung
+            %h2 Wetterkrieg$fuehrung
             %audio{ :controls => "controls"}
                 %source{ :src => "data/wkf.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/wkf.ogg", :type => "audio/ogg"}
@@ -149,7 +149,7 @@
                 %source{ :src => "data/kraftmassebeschleunigung.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/kraftmassebeschleunigung.ogg", :type => "audio/ogg"}
         .klang
-            %h2 Das Internet ist scheisse
+            %h2 Das Internet ist scheis$e
             %audio{ :controls => "controls"}
                 %source{ :src => "data/internetistscheisse.mp3", :type => "audio/mp3"}
                 %source{ :src => "data/internetistscheisse.ogg", :type => "audio/ogg"}


### PR DESCRIPTION
- Lang-s durch ein Rund-s ausgetauscht (Silbenende)
- "Widerstand" zu "Wiederstand" korrigiert.
(fixes #10)